### PR TITLE
Added easykey, key, betterbibtexkey display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ How does it work?
 
 Press `<Control><Alt>-I` or go to Insert -> Citations. A dialog will open up, where you can enter your query to search for items in your Zotero collection. After pressing `GO`, all the matching items will be added into your zim wiki.
 
-Changing the default display style
+Changing the default link display format
 ------------------------
 
 In zim go to Edit -> Preferences -> Plugins -> Zotero Citations
-Under `Configure` you can choose the display style of Zotero links in zim:
+Under `Configure` you can choose the display format of Zotero links in zim:
 
 - `betterbibtexkey`, e.g. *bloomAreIdeasGetting2017*
 - `easykey`, e.g. *bloom:2017are*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 zim-zotero-plugin
 =================
 
-This ZIM Wiki plugin provides integration between Zotero (Reference Manager) and Zim (Personal Wiki Software).
+This ZIM Wiki plugin provides integration between Zotero (Reference Manager) and zim (Personal Wiki Software).
 
-Clone this repo to your plugins folder and restart your Zim wiki:
+Clone this repo to your plugins folder and restart your zim wiki:
 
     git clone https://github.com/shivams/zim-zotero-plugin ~/.local/share/zim/plugins/zim-zotero-plugin
 
@@ -12,12 +12,23 @@ Note that you will need to install `zotxt` (https://github.com/egh/zotxt) plugin
 How does it work?
 -----------------
 
-Press `<Control><Alt>-I` or go to Insert -> Citations. A dialog will open up, where you can enter your query to search for items in your Zotero collection. After pressing `GO`, all the matching items will be added into your Zim Wiki.
+Press `<Control><Alt>-I` or go to Insert -> Citations. A dialog will open up, where you can enter your query to search for items in your Zotero collection. After pressing `GO`, all the matching items will be added into your zim wiki.
+
+Changing the default display style
+------------------------
+
+In zim go to Edit -> Preferences -> Plugins -> Zotero Citations
+Under `Configure` you can choose the display style of Zotero links in zim:
+
+- `betterbibtexkey`, e.g. *bloomAreIdeasGetting2017*
+- `easykey`, e.g. *bloom:2017are*
+- `key`, e.g. *1_MGYAJ483*
+- `bibliography`, e.g. *Bloom, Nicholas, Charles Jones, John Van Reenen, and Michael Webb. “Are Ideas Getting Harder to Find?,” 2017. https://doi.org/10.3386/w23782.*
 
 Handling zotero:// Links
 ------------------------
 
-~~Items, that are added, are linked to Zotero using the `zotero://` identifier. Currently, Zim doesn't handle this identifier. So, you will have to create a custom script. A small such script is available in the repo: `zotero_link_handler.sh`. Copy it somewhere in your PATH. And then, when in Zim, right click on the Zotero links and click Open With -> Customize, and add this custom script.~~
+~~Items, that are added, are linked to Zotero using the `zotero://` identifier. Currently, zim doesn't handle this identifier. So, you will have to create a custom script. A small such script is available in the repo: `zotero_link_handler.sh`. Copy it somewhere in your PATH. And then, when in zim, right click on the Zotero links and click Open With -> Customize, and add this custom script.~~
 
 No need of external scripts to handle zotero links. Now, the plugin handles all the links itself. When you click on any Zotero link in your Notebook, the particular reference is highlighted in Zotero.
 
@@ -26,7 +37,5 @@ TODOs
 
 - [ ] Intra-page References
   - See this launchpad wishlist: https://bugs.launchpad.net/zim/+bug/380844
-  - And this blueprint by Jaap (Zim BDFL): https://github.com/jaap-karssenberg/zim-wiki/wiki/Blueprint-anchors
+  - And this blueprint by Jaap (zim BDFL): https://github.com/jaap-karssenberg/zim-wiki/wiki/Blueprint-anchors
 - [ ] Bibtex Support
-
-

--- a/__init__.py
+++ b/__init__.py
@@ -122,7 +122,6 @@ class ZoteroDialog(Dialog):
         url = 'http://' + root + '/search?q=' + text + format + method
         try:
             resp = json.loads(urllib2.urlopen(url).read())
-            buffer.insert_at_cursor(url)
             if style == 'bibliography':
                 for i in resp:
                     key = i['key']

--- a/__init__.py
+++ b/__init__.py
@@ -37,7 +37,7 @@ class ZoteroPlugin(PluginClass):
             return False
 
     plugin_preferences = (
-        ('bibliography_style', 'choice', _('Bibliography Style'),
+        ('link_format', 'choice', _('Link Format'),
          'betterbibtexkey',
          ('betterbibtexkey', 'easykey', 'key', 'bibliography')),
     )
@@ -117,12 +117,12 @@ class ZoteroDialog(Dialog):
             method = '&method=fields'
         elif "Everywhere" in radiotext:
             method = '&method=everything'
-        style = self.preferences['bibliography_style']
-        format = '&format=' + style
+        link_format = self.preferences['link_format']
+        format = '&format=' + link_format
         url = 'http://' + root + '/search?q=' + text + format + method
         try:
             resp = json.loads(urllib2.urlopen(url).read())
-            if style == 'bibliography':
+            if link_format == 'bibliography':
                 for i in resp:
                     key = i['key']
                     try:
@@ -132,7 +132,7 @@ class ZoteroDialog(Dialog):
                         buffer.insert_at_cursor("\n")
                     except:
                         pass
-            elif style == 'betterbibtexkey':
+            elif link_format == 'betterbibtexkey':
                 for key in resp:
                     try:
                         zotlink = ('zotero://' + root +
@@ -141,7 +141,7 @@ class ZoteroDialog(Dialog):
                         buffer.insert_at_cursor("\n")
                     except:
                         pass
-            elif style == 'easykey':
+            elif link_format == 'easykey':
                 for key in resp:
                     try:
                         zotlink = ('zotero://' + root +
@@ -150,7 +150,7 @@ class ZoteroDialog(Dialog):
                         buffer.insert_at_cursor("\n")
                     except:
                         pass
-            elif style == 'key':
+            elif link_format == 'key':
                 for key in resp:
                     try:
                         zotlink = ('zotero://' + root +
@@ -160,6 +160,7 @@ class ZoteroDialog(Dialog):
                     except:
                         pass
             else:
-                buffer.insert_at_cursor('style unknown: ' + style + "\n")
+                buffer.insert_at_cursor('link format unknown: ' + link_format
+                                        + "\n")
         except:
             pass

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ class ZoteroPlugin(PluginClass):
     """plugin info for zim."""
 
     plugin_info = {
-        'name': _('Zotero Citations modified'),
+        'name': _('Zotero Citations'),
         'description': _('Zotero is a free cross-platform desktop reference and paper management program (http://www.zotero.org/).'
                          'This plugin allows you to insert Zotero citations that link directly to the Zotero desktop application.'
                          'You need to install the "zotxt" plugin in Zotero application, and the Zotero application must be running'

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,6 @@ from zim.applications import Application, ApplicationError
 from zim.gui.widgets import Dialog, Button, InputEntry, ScrolledWindow
 import json
 import urllib2
-# import requests
 
 
 class ZoteroPlugin(PluginClass):
@@ -41,7 +40,8 @@ class ZoteroPlugin(PluginClass):
 
     plugin_preferences = (
         ('bibliography_style', 'choice', _('Bibliography Style'),
-         'bbtkey', ('bbtkey', 'easykey', 'key', 'bibliography')),
+         'betterbibtexkey',
+         ('betterbibtexkey', 'easykey', 'key', 'bibliography')),
     )
 
 
@@ -53,7 +53,7 @@ class MainWindowExtension(WindowExtension):
         <menubar name='menubar'>
             <menu action='insert_menu'>
                 <placeholder name='plugin_items'>
-                    <menuitem action='insert_citation_bbt'/>
+                    <menuitem action='insert_citation'/>
                 </placeholder>
             </menu>
         </menubar>
@@ -63,18 +63,19 @@ class MainWindowExtension(WindowExtension):
     def __init__(self, plugin, window):
         """Window constructor."""
         WindowExtension.__init__(self, plugin, window)
-        self.window.ui.register_url_handler('zotero', self.plugin.zotero_handle)
+        self.preferences = plugin.preferences
+        self.window.ui.register_url_handler('zotero',
+                                            self.plugin.zotero_handle)
 
     @action(_('_Citation...'), '', '<Primary><Alt>I')  # T: menu item
-    def insert_citation_bbt(self):
+    def insert_citation(self):
         """Will be called by the menu item or key binding."""
-        # print dir(self.window)
-        ZoteroDialog(self.window, self.window.pageview).run()
+        ZoteroDialog(self.window, self.window.pageview, self.preferences).run()
 
 
 class ZoteroDialog(Dialog):
 
-    def __init__(self, ui, pageview):
+    def __init__(self, ui, pageview, preferences):
         Dialog.__init__(self, ui, _('Search in Zotero'),  # T: Dialog title
                         button=(_('_GO'), 'gtk-ok'),  # T: Button label
                         defaultwindowsize=(350, 200))
@@ -82,6 +83,7 @@ class ZoteroDialog(Dialog):
         self.pageview = pageview
         self.textentry = InputEntry()
         self.vbox.pack_start(self.textentry, False)
+        self.preferences = preferences
         first = None
         options = ["Search in Title, Author and Date",
                    "Search in All Fields and Tags",
@@ -102,7 +104,7 @@ class ZoteroDialog(Dialog):
         buffer = self.pageview.view.get_buffer()
         active = [r for r in self.radio.get_group() if r.get_active()]  # @+
         radiotext = active[0].get_label()  # @+
-        self.insert_citation_bbt(text, radiotext, buffer)
+        self.insert_citation(text, radiotext, buffer)
         return True
 
     def insert_citation(self, text, radiotext, buffer):
@@ -113,44 +115,32 @@ class ZoteroDialog(Dialog):
             method = '&method=fields'
         elif "Everywhere" in radiotext:
             method = '&method=everything'
-        format = '&format=bibliography'
-        url = 'http://' + root + '/search?q=' + text + format + method
-        try:
-            # resp = requests.get(url).json()
-            resp = json.loads(urllib2.urlopen(url).read())
-            for i in resp:
-                key = i['key']
-                # key = '0_' + i['id'].split('/')[-1]
-                # Sometimes, articles may have missing fields, can be skipped
-                try:
-                    href = 'zotero://' + root + '/select?key=' + key
-                    # title = i['title']
-                    bibtext = i['text']
-                    buffer.insert_link_at_cursor(bibtext, href=href)
-                    buffer.insert_at_cursor("\n")
-                except:
-                    pass
-        except:
-            pass
-
-    def insert_citation_bbt(self, text, radiotext, buffer):
-        """Will insert the BBT keys returned by zotero."""
-        root = "127.0.0.1:23119/zotxt"
-        format = '&format=betterbibtexkey'
-        method = ''  # Method defaults to titleCreatorYear
-        if "Tags" in radiotext:
-            method = '&method=fields'
-        elif "Everywhere" in radiotext:
-            method = '&method=everything'
+        style = self.preferences['bibliography_style']
+        format = '&format=' + style
         url = 'http://' + root + '/search?q=' + text + format + method
         try:
             resp = json.loads(urllib2.urlopen(url).read())
-            for bbtkey in resp:
-                try:
-                    zotlink = 'zotero://' + root + '/select?betterbibtexkey=' + bbtkey
-                    buffer.insert_link_at_cursor(bbtkey, href=zotlink)
-                    buffer.insert_at_cursor("\n")
-                except:
-                    pass
+            if style == 'bibliography':
+                for i in resp:
+                    buffer.insert_at_cursor(i)
+                    key = i['key']
+                    try:
+                        zotlink = 'zotero://' + root + '/select?key=' + key
+                        bibtext = i['text']
+                        buffer.insert_link_at_cursor(bibtext, href=zotlink)
+                        buffer.insert_at_cursor("\n")
+                    except:
+                        pass
+            elif style == 'betterbibtexkey':
+                for bbtkey in resp:
+                    try:
+                        zotlink = ('zotero://' + root +
+                                   '/select?betterbibtexkey=' + bbtkey)
+                        buffer.insert_link_at_cursor(bbtkey, href=zotlink)
+                        buffer.insert_at_cursor("\n")
+                    except:
+                        pass
+            else:
+                buffer.insert_at_cursor('style unknown: ' + style + "\n")
         except:
             pass

--- a/__init__.py
+++ b/__init__.py
@@ -16,20 +16,20 @@ import urllib2
 
 
 class ZoteroPlugin(PluginClass):
+    """plugin info for zim."""
 
     plugin_info = {
-        'name': _('Zotero Citations'), # T: plugin name
+        'name': _('Zotero Citations'),
         'description': _('Zotero is a free cross-platform desktop reference and paper management program (http://www.zotero.org/).'
                          'This plugin allows you to insert Zotero citations that link directly to the Zotero desktop application.'
                          'You need to install the "zotxt" plugin in Zotero application, and the Zotero application must be running'
-                         ' for this plugin to function.'), # T: plugin description
+                         ' for this plugin to function.'),
         'author': 'Shivam Sharma',
         'help': 'Plugins:Zotero Citations',
     }
 
     def zotero_handle(self, link):
-        '''This handles zotereo links of the form zotero://
-        '''
+        """Handles zotereo links of the form zotero://."""
         url = link.replace('zotero', 'http')
         try:
             if "success" in urllib2.urlopen(url).read().lower():
@@ -38,7 +38,6 @@ class ZoteroPlugin(PluginClass):
                 return False
         except:
             return False
-
 
 
 @extends('MainWindow')
@@ -57,14 +56,13 @@ class MainWindowExtension(WindowExtension):
     '''
 
     def __init__(self, plugin, window):
-        ''' Constructor '''
+        """Constructor"""
         WindowExtension.__init__(self, plugin, window)
         self.window.ui.register_url_handler('zotero', self.plugin.zotero_handle)
 
-    @action(_('_Citation...'), '', '<Primary><Alt>I') # T: menu item
+    @action(_('_Citation...'), '', '<Primary><Alt>I')  # T: menu item
     def insert_citation(self):
-        '''Action called by the menu item or key binding,
-        '''
+        """Action called by the menu item or key binding"""
         # print dir(self.window)
         ZoteroDialog(self.window, self.window.pageview).run()
 
@@ -72,9 +70,9 @@ class MainWindowExtension(WindowExtension):
 class ZoteroDialog(Dialog):
 
     def __init__(self, ui, pageview):
-        Dialog.__init__(self, ui, _('Search in Zotero'), # T: Dialog title
+        Dialog.__init__(self, ui, _('Search in Zotero'),  # T: Dialog title
                         button=(_('_GO'), 'gtk-ok'),  # T: Button label
-                        defaultwindowsize=(350, 200) )
+                        defaultwindowsize=(350, 200))
 
         self.pageview = pageview
         self.textentry = InputEntry()
@@ -84,10 +82,10 @@ class ZoteroDialog(Dialog):
                    "Search in All Fields and Tags",
                    "Search Everywhere"]
         for text in options:
-            self.radio = gtk.RadioButton( first, text)
+            self.radio = gtk.RadioButton(first, text)
             if not first:
                 first = self.radio
-            self.vbox.pack_start( self.radio, expand=False)
+            self.vbox.pack_start(self.radio, expand=False)
             self.radio.show()
 
     def run(self):
@@ -96,15 +94,15 @@ class ZoteroDialog(Dialog):
     def do_response_ok(self):
         text = self.textentry.get_text()
         buffer = self.pageview.view.get_buffer()
-        active = [r for r in self.radio.get_group() if r.get_active()] #@+
-        radiotext = active[0].get_label() #@+
+        active = [r for r in self.radio.get_group() if r.get_active()]  # @+
+        radiotext = active[0].get_label()  # @+
         self.insert_citation(text, radiotext, buffer)
         return True
 
     def insert_citation(self, text, radiotext, buffer):
         root = "127.0.0.1:23119/zotxt"
         format = '&format=bibliography'
-        method = '' #Method defaults to titleCreatorYear
+        method = ''  # Method defaults to titleCreatorYear
         if "Tags" in radiotext:
             method = '&method=fields'
         elif "Everywhere" in radiotext:
@@ -116,9 +114,9 @@ class ZoteroDialog(Dialog):
             for i in resp:
                 key = i['key']
                 # key = '0_' + i['id'].split('/')[-1]
-                #Sometimes, articles may have missing fields, so they can be skipped
+                # Sometimes, articles may have missing fields, can be skipped
                 try:
-                    href =  'zotero://' + root + '/select?key=' + key
+                    href = 'zotero://' + root + '/select?key=' + key
                     # title = i['title']
                     bibtext = i['text']
                     buffer.insert_link_at_cursor(bibtext, href=href)

--- a/__init__.py
+++ b/__init__.py
@@ -122,9 +122,9 @@ class ZoteroDialog(Dialog):
         url = 'http://' + root + '/search?q=' + text + format + method
         try:
             resp = json.loads(urllib2.urlopen(url).read())
+            buffer.insert_at_cursor(url)
             if style == 'bibliography':
                 for i in resp:
-                    buffer.insert_at_cursor(i)
                     key = i['key']
                     try:
                         zotlink = 'zotero://' + root + '/select?key=' + key
@@ -134,11 +134,29 @@ class ZoteroDialog(Dialog):
                     except:
                         pass
             elif style == 'betterbibtexkey':
-                for bbtkey in resp:
+                for key in resp:
                     try:
                         zotlink = ('zotero://' + root +
-                                   '/select?betterbibtexkey=' + bbtkey)
-                        buffer.insert_link_at_cursor(bbtkey, href=zotlink)
+                                   '/select?betterbibtexkey=' + key)
+                        buffer.insert_link_at_cursor(key, href=zotlink)
+                        buffer.insert_at_cursor("\n")
+                    except:
+                        pass
+            elif style == 'easykey':
+                for key in resp:
+                    try:
+                        zotlink = ('zotero://' + root +
+                                   '/select?key=' + key)
+                        buffer.insert_link_at_cursor(key, href=zotlink)
+                        buffer.insert_at_cursor("\n")
+                    except:
+                        pass
+            elif style == 'key':
+                for key in resp:
+                    try:
+                        zotlink = ('zotero://' + root +
+                                   '/select?easykey=' + key)
+                        buffer.insert_link_at_cursor(key, href=zotlink)
                         buffer.insert_at_cursor("\n")
                     except:
                         pass

--- a/__init__.py
+++ b/__init__.py
@@ -6,10 +6,8 @@
 
 import gtk
 from zim.plugins import PluginClass, extends, WindowExtension
-from zim.errors import Error
 from zim.actions import action
-from zim.applications import Application, ApplicationError
-from zim.gui.widgets import Dialog, Button, InputEntry, ScrolledWindow
+from zim.gui.widgets import Dialog, InputEntry
 import json
 import urllib2
 
@@ -47,6 +45,7 @@ class ZoteroPlugin(PluginClass):
 
 @extends('MainWindow')
 class MainWindowExtension(WindowExtension):
+    """Define the input window."""
 
     uimanager_xml = '''
     <ui>
@@ -74,8 +73,10 @@ class MainWindowExtension(WindowExtension):
 
 
 class ZoteroDialog(Dialog):
+    """The Zotero specific Input Dialog."""
 
     def __init__(self, ui, pageview, preferences):
+        """Initialize the Input Box with options."""
         Dialog.__init__(self, ui, _('Search in Zotero'),  # T: Dialog title
                         button=(_('_GO'), 'gtk-ok'),  # T: Button label
                         defaultwindowsize=(350, 200))
@@ -96,6 +97,7 @@ class ZoteroDialog(Dialog):
             self.radio.show()
 
     def run(self):
+        """Call the widget.dialog.run method."""
         Dialog.run(self)
 
     def do_response_ok(self):


### PR DESCRIPTION
To not have the full citation information in the zim notebook, the plugin can now be set to use the Zotero *key*, *easykey* or *betterbibtexkey* options.
This also fixes [issue#5](https://github.com/shivams/zim-zotero-plugin/issues/5).

The desired link style can be chosen in the configure menu.