### PR TITLE
Updated to work with zim 0.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Handling zotero:// Links
 
 ~~Items, that are added, are linked to Zotero using the `zotero://` identifier. Currently, zim doesn't handle this identifier. So, you will have to create a custom script. A small such script is available in the repo: `zotero_link_handler.sh`. Copy it somewhere in your PATH. And then, when in zim, right click on the Zotero links and click Open With -> Customize, and add this custom script.~~
 
-No need of external scripts to handle zotero links. Now, the plugin handles all the links itself. When you click on any Zotero link in your Notebook, the particular reference is highlighted in Zotero.
+~~No need of external scripts to handle zotero links. Now, the plugin handles all the links itself. When you click on any Zotero link in your Notebook, the particular reference is highlighted in Zotero.~~
+
+Sad to say, but we are back to the original state, I did not find a way to make zim open `zotero://` links by default in zim 0.70. Hence now you should again take the `zotero_link_handler.sh`, put it on your PATH (and make it executable). Then, when in zim, right click on the Zotero links and click Open With -> Customize, and fill in `zotero_link_handler.sh` as command.
 
 TODOs
 -----

--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,6 @@ from zim.plugins import PluginClass
 from zim.gui.pageview import PageViewExtension
 from zim.actions import action
 from zim.gui.widgets import Dialog, InputEntry
-from zim.gui.applications import open_url
 import json
 try:
     # For Python 3.0 and later
@@ -28,20 +27,20 @@ class ZoteroPlugin(PluginClass):
                          'This plugin allows you to insert Zotero citations that link directly to the Zotero desktop application.'
                          'You need to install the "zotxt" plugin in Zotero application, and the Zotero application must be running'
                          ' for this plugin to function.'),
-        'authors': 'Shivam Sharma, Ian Cynk',
+        'authors': 'Shivam Sharma',
         'help': 'Plugins:Zotero Citations',
     }
 
-    def zotero_handle(self, link):
-        """Handle Zotero links of the form zotero://."""
-        url = link.replace('zotero', 'http')
-        try:
-            if "success" in urlopen(url).read().lower():
-                return True
-            else:
-                return False
-        except:
-            return False
+    # def zotero_handle(self, link):
+    #     """Handle Zotero links of the form zotero://."""
+    #     url = link.replace('zotero', 'http')
+    #     try:
+    #         if "success" in urlopen(url).read().lower():
+    #             return True
+    #         else:
+    #             return False
+    #     except:
+    #         return False
 
     plugin_preferences = (
         ('link_format', 'choice', _('Link Format'),
@@ -50,8 +49,6 @@ class ZoteroPlugin(PluginClass):
     )
 
 
-
-# class ZoteroWindowExtension(MainWindowExtension):
 class ZoteroPageViewExtension(PageViewExtension):
     """Define the input window."""
 
@@ -59,14 +56,13 @@ class ZoteroPageViewExtension(PageViewExtension):
         """Window constructor."""
         PageViewExtension.__init__(self, plugin, pageview)
         self.preferences = plugin.preferences
-        # self.ui.register_url_handler('zotero',
-                                            # self.plugin.zotero_handle)
 
     @action(_('_Citation...'), accelerator='<Primary><Alt>I', menuhints='notebook')  # T: menu item
     def insert_citation(self):
         """Will be called by the menu item or key binding."""
         dialog = ZoteroDialog.unique(self, self.pageview, self.preferences)
         dialog.show_all()
+
 
 class ZoteroDialog(Dialog):
     """The Zotero specific Input Dialog."""

--- a/__init__.py
+++ b/__init__.py
@@ -4,12 +4,19 @@
 # License: GNU GPL v2 or higher
 
 
-import gtk
-from zim.plugins import PluginClass, extends, WindowExtension
+from gi.repository import Gtk
+from zim.plugins import PluginClass
+from zim.gui.pageview import PageViewExtension
 from zim.actions import action
 from zim.gui.widgets import Dialog, InputEntry
+from zim.gui.applications import open_url
 import json
-import urllib2
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
 
 
 class ZoteroPlugin(PluginClass):
@@ -21,7 +28,7 @@ class ZoteroPlugin(PluginClass):
                          'This plugin allows you to insert Zotero citations that link directly to the Zotero desktop application.'
                          'You need to install the "zotxt" plugin in Zotero application, and the Zotero application must be running'
                          ' for this plugin to function.'),
-        'author': 'Shivam Sharma',
+        'authors': 'Shivam Sharma, Ian Cynk',
         'help': 'Plugins:Zotero Citations',
     }
 
@@ -29,7 +36,7 @@ class ZoteroPlugin(PluginClass):
         """Handle Zotero links of the form zotero://."""
         url = link.replace('zotero', 'http')
         try:
-            if "success" in urllib2.urlopen(url).read().lower():
+            if "success" in urlopen(url).read().lower():
                 return True
             else:
                 return False
@@ -43,57 +50,46 @@ class ZoteroPlugin(PluginClass):
     )
 
 
-@extends('MainWindow')
-class MainWindowExtension(WindowExtension):
+
+# class ZoteroWindowExtension(MainWindowExtension):
+class ZoteroPageViewExtension(PageViewExtension):
     """Define the input window."""
 
-    uimanager_xml = '''
-    <ui>
-        <menubar name='menubar'>
-            <menu action='insert_menu'>
-                <placeholder name='plugin_items'>
-                    <menuitem action='insert_citation'/>
-                </placeholder>
-            </menu>
-        </menubar>
-    </ui>
-    '''
-
-    def __init__(self, plugin, window):
+    def __init__(self, plugin, pageview):
         """Window constructor."""
-        WindowExtension.__init__(self, plugin, window)
+        PageViewExtension.__init__(self, plugin, pageview)
         self.preferences = plugin.preferences
-        self.window.ui.register_url_handler('zotero',
-                                            self.plugin.zotero_handle)
+        # self.ui.register_url_handler('zotero',
+                                            # self.plugin.zotero_handle)
 
-    @action(_('_Citation...'), '', '<Primary><Alt>I')  # T: menu item
+    @action(_('_Citation...'), accelerator='<Primary><Alt>I', menuhints='notebook')  # T: menu item
     def insert_citation(self):
         """Will be called by the menu item or key binding."""
-        ZoteroDialog(self.window, self.window.pageview, self.preferences).run()
-
+        dialog = ZoteroDialog.unique(self, self.pageview, self.preferences)
+        dialog.show_all()
 
 class ZoteroDialog(Dialog):
     """The Zotero specific Input Dialog."""
 
-    def __init__(self, ui, pageview, preferences):
+    def __init__(self, pageview, preferences):
         """Initialize the Input Box with options."""
-        Dialog.__init__(self, ui, _('Search in Zotero'),  # T: Dialog title
-                        button=(_('_GO'), 'gtk-ok'),  # T: Button label
+        Dialog.__init__(self, pageview, _('Search in Zotero'),  # T: Dialog title
+                        button=_('_GO'),  # T: Button label
                         defaultwindowsize=(350, 200))
 
         self.pageview = pageview
         self.textentry = InputEntry()
-        self.vbox.pack_start(self.textentry, False)
+        self.vbox.pack_start(self.textentry, False, True, 0)
         self.preferences = preferences
         first = None
         options = ["Search in Title, Author and Date",
                    "Search in All Fields and Tags",
                    "Search Everywhere"]
         for text in options:
-            self.radio = gtk.RadioButton(first, text)
+            self.radio = Gtk.RadioButton(first, text)
             if not first:
                 first = self.radio
-            self.vbox.pack_start(self.radio, expand=False)
+            self.vbox.pack_start(self.radio, False, True, 0)
             self.radio.show()
 
     def run(self):
@@ -103,7 +99,7 @@ class ZoteroDialog(Dialog):
     def do_response_ok(self):
         """Call to insert citation when pressing ok."""
         text = self.textentry.get_text()
-        buffer = self.pageview.view.get_buffer()
+        buffer = self.pageview.textview.get_buffer()
         active = [r for r in self.radio.get_group() if r.get_active()]  # @+
         radiotext = active[0].get_label()  # @+
         self.insert_citation(text, radiotext, buffer)
@@ -121,7 +117,7 @@ class ZoteroDialog(Dialog):
         format = '&format=' + link_format
         url = 'http://' + root + '/search?q=' + text + format + method
         try:
-            resp = json.loads(urllib2.urlopen(url).read())
+            resp = json.loads(urlopen(url).read())
             if link_format == 'bibliography':
                 for i in resp:
                     key = i['key']

--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ class ZoteroPlugin(PluginClass):
                          'This plugin allows you to insert Zotero citations that link directly to the Zotero desktop application.'
                          'You need to install the "zotxt" plugin in Zotero application, and the Zotero application must be running'
                          ' for this plugin to function.'),
-        'authors': 'Shivam Sharma',
+        'author': 'Shivam Sharma',
         'help': 'Plugins:Zotero Citations',
     }
 
@@ -57,7 +57,7 @@ class ZoteroPageViewExtension(PageViewExtension):
         PageViewExtension.__init__(self, plugin, pageview)
         self.preferences = plugin.preferences
 
-    @action(_('_Citation...'), accelerator='<Primary><Alt>I', menuhints='notebook')  # T: menu item
+    @action(_('_Citation...'), accelerator='<Primary><Alt>I', menuhints='insert')  # T: menu item
     def insert_citation(self):
         """Will be called by the menu item or key binding."""
         dialog = ZoteroDialog.unique(self, self.pageview, self.preferences)
@@ -77,12 +77,19 @@ class ZoteroDialog(Dialog):
         self.textentry = InputEntry()
         self.vbox.pack_start(self.textentry, False, True, 0)
         self.preferences = preferences
+
+        # self.radio1 = Gtk.RadioButton.new_with_mnemonic_from_widget(None, _('Search in Title, Author and Date'))
+        # self.radio2 = Gtk.RadioButton.new_with_mnemonic_from_widget(self.radio1, _('Search in All Fields and Tags'))
+        # self.radio3 = Gtk.RadioButton.new_with_mnemonic_from_widget(self.radio2, _('Search Everywhere'))
+        # self.vbox.add(self.radio1)
+        # self.vbox.add(self.radio2)
+        # self.vbox.add(self.radio3)
         first = None
         options = ["Search in Title, Author and Date",
                    "Search in All Fields and Tags",
                    "Search Everywhere"]
         for text in options:
-            self.radio = Gtk.RadioButton(first, text)
+            self.radio = Gtk.RadioButton.new_with_mnemonic_from_widget(first, text)
             if not first:
                 first = self.radio
             self.vbox.pack_start(self.radio, False, True, 0)

--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,7 @@ class ZoteroPlugin(PluginClass):
         'author': 'Shivam Sharma',
         'help': 'Plugins:Zotero Citations',
     }
-
+# sadly this does not work anymore
     # def zotero_handle(self, link):
     #     """Handle Zotero links of the form zotero://."""
     #     url = link.replace('zotero', 'http')
@@ -77,13 +77,6 @@ class ZoteroDialog(Dialog):
         self.textentry = InputEntry()
         self.vbox.pack_start(self.textentry, False, True, 0)
         self.preferences = preferences
-
-        # self.radio1 = Gtk.RadioButton.new_with_mnemonic_from_widget(None, _('Search in Title, Author and Date'))
-        # self.radio2 = Gtk.RadioButton.new_with_mnemonic_from_widget(self.radio1, _('Search in All Fields and Tags'))
-        # self.radio3 = Gtk.RadioButton.new_with_mnemonic_from_widget(self.radio2, _('Search Everywhere'))
-        # self.vbox.add(self.radio1)
-        # self.vbox.add(self.radio2)
-        # self.vbox.add(self.radio3)
         first = None
         options = ["Search in Title, Author and Date",
                    "Search in All Fields and Tags",


### PR DESCRIPTION
The former zotero plugin version stopped working in zim0.70 because WindowExtension and some other elements got removed. Had to rework it with Pageview. 
Sadly I was unable to find a way to replace the register_url_handle, hence now you need to use a script again to call Zotero with zotero links.
Still, after setting up that script it works nice for me. 