### PR TITLE
[WiP] Rework the Dialog and change to Zotero's link handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ If Zotero is not set as default, you can try to set it with
 In the worst case you need to right click on a Zotero link and click *Open 
 with* -> *Customize* and select Zotero as standard application.
 
+### Alternative using the zotxt
+
+If the way above is not working. There is the `zotero-zotxt.py` script which 
+could be used. Add another desktop entry:
+
+    $ cat .local/share/applications/zotero-zotxt.desktop
+    [Desktop Entry]
+    Name=Zotero zotxt wrapper
+    TryExec=zotero
+    Exec=python3 path/to/zotero-zotxt.py %U
+    Icon=Path_to_Zotero/chrome/icons/default/default256.png
+    Type=Application
+    Terminal=false
+    Categories=Office;
+    MimeType=x-scheme-handler/zotero;text/html;text/plain
+
+Update the database as written above and set now `zotero-zotxt.desktop` as 
+default:
+
+    gio x-scheme-handler/zotero zotero-zotxt.desktop
+
 TODOs
 -----
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Clone this repo to your plugins folder and restart your zim wiki:
 
 Note that you will need to install `zotxt` (https://github.com/egh/zotxt) plugin in your Zotero to make this plugin work.
 
+Warning
+-------
+
+This version is not compatible to older ones. **The link format has changed.** 
+It follows the direct supported link format of Zotero and therefore it can not 
+support the easylink format.
+
 How does it work?
 -----------------
 
@@ -18,21 +25,60 @@ Changing the default link display format
 ------------------------
 
 In zim go to Edit -> Preferences -> Plugins -> Zotero Citations
+
 Under `Configure` you can choose the display format of Zotero links in zim:
 
 - `betterbibtexkey`, e.g. *bloomAreIdeasGetting2017*
-- `easykey`, e.g. *bloom:2017are*
 - `key`, e.g. *1_MGYAJ483*
 - `bibliography`, e.g. *Bloom, Nicholas, Charles Jones, John Van Reenen, and Michael Webb. “Are Ideas Getting Harder to Find?,” 2017. https://doi.org/10.3386/w23782.*
+
+The option `Bibliography Style` can now change the citation style used by the 
+option `bibliography`. Be careful as the option shown in Zotero needs mostly to 
+be transformed.
+
+    RTF Style -> rft-style
 
 Handling zotero:// Links
 ------------------------
 
-~~Items, that are added, are linked to Zotero using the `zotero://` identifier. Currently, zim doesn't handle this identifier. So, you will have to create a custom script. A small such script is available in the repo: `zotero_link_handler.sh`. Copy it somewhere in your PATH. And then, when in zim, right click on the Zotero links and click Open With -> Customize, and add this custom script.~~
+Under Linux you need now a `zotero.desktop` for handling the links. The link 
+should work then in every program. The important part is the 
+`MimeType=x-scheme-handler/zotero;`. With it Zotero is used for `zotero://` 
+links. Adjust your path to Zotero!
 
-~~No need of external scripts to handle zotero links. Now, the plugin handles all the links itself. When you click on any Zotero link in your Notebook, the particular reference is highlighted in Zotero.~~
+    $ cat .local/share/applications/zotero.desktop
+    [Desktop Entry]
+    Name=Zotero
+    TryExec=zotero
+    Exec=zotero -url %U
+    Icon=Path_to_Zotero/chrome/icons/default/default256.png
+    Type=Application
+    Terminal=false
+    Categories=Office;
+    MimeType=x-scheme-handler/zotero;text/html;text/plain
 
-Sad to say, but we are back to the original state, I did not find a way to make zim open `zotero://` links by default in zim 0.70. Hence now you should again take the `zotero_link_handler.sh`, put it on your PATH (and make it executable). Then, when in zim, right click on the Zotero links and click Open With -> Customize, and fill in `zotero_link_handler.sh` as command.
+After updating the mime-database and a zim restart, zim should find Zotero and 
+open the links with it.
+
+    update-mime-database ~/.local/share/mime
+    update-desktop-database ~/.local/share/applications
+
+If the Zotero handler is in the database, the output of `gio` should look like 
+this:
+
+    $ gio mime x-scheme-handler/zotero
+    Default application for »x-scheme-handler/zotero«: zotero.desktop
+    Registered applications:
+            zotero.desktop
+    Recommended applications:
+            zotero.desktop
+
+If Zotero is not set as default, you can try to set it with
+
+    gio x-scheme-handler/zotero zotero.desktop
+
+In the worst case you need to right click on a Zotero link and click *Open 
+with* -> *Customize* and select Zotero as standard application.
 
 TODOs
 -----

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Warning
 
 This version is not compatible to older ones. **The link format has changed.** 
 It follows the direct supported link format of Zotero and therefore it can not 
-support the easylink format.
+support the easylink format. The old easylink format will have the Zotero key 
+as its address.
 
 ###Convert the old link format into Zotero links
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This version is not compatible to older ones. **The link format has changed.**
 It follows the direct supported link format of Zotero and therefore it can not 
 support the easylink format.
 
+###Convert the old link format into Zotero links
+
+The script will do a move of the original txt files and copy the content to the 
+original name while rewriting the Zotero links. The backup of original file is 
+not changed.
+
+**Warning:** a second run will overwrite the backup files!
+
+	python3 update_links.py path/to/zim-wiki
+
 How does it work?
 -----------------
 

--- a/__init__.py
+++ b/__init__.py
@@ -94,7 +94,7 @@ class ZoteroDialog(Dialog):
         link_format = self.preferences['link_format']
         bibliography_style = self.preferences['bibliography_style']
 
-        if link_format == 'bibliography' and bibliography_style != '':
+        if link_format == 'bibliography' and bibliography_style is not None:
             data['style'] = bibliography_style
 
         data['method'] = self.form['search']

--- a/__init__.py
+++ b/__init__.py
@@ -135,7 +135,8 @@ class ZoteroDialog(Dialog):
                 ErrorDialog(self, 'link format unknown: ' + link_format).run()
                 return False
         except Exception as error:
-            ErrorDialog(self, str(error)).run()
+            errorstr = "While executing the request to Zotero, a error happend" + str(error) + "\n" + url
+            ErrorDialog(self, errorstr).run()
             return False
         return True
 

--- a/update_links.py
+++ b/update_links.py
@@ -27,14 +27,12 @@ def matchkey(m):
         try:
             key = fetchkey(m.group(2))
         except Exception as e:
-            print(f'ERROR: got an exception {e}')
-            print(m.group[0])
+            print(f'ERROR: got an exception {e}\n{m.group(0)}')
     elif m.group(1) == 'betterbibtex':
         key = '@' + m.group(2)
     else:
         key = ''
         print(f'ERROR: found something unspecified: {m.group(0)}')
-        print(m.group[0])
     return f'[[zotero://select/items/{key}|{m.group(3)}]]'
 
 def updatefile(filename, backup=True):

--- a/update_links.py
+++ b/update_links.py
@@ -1,0 +1,78 @@
+#!/bin/python3
+
+import os
+import re
+import json
+from urllib.request import urlopen
+from urllib.parse import urlencode
+
+patternkey = re.compile(r'\[\[zotero://[\d\.:]+/zotxt/select\?(\w*)key=([\w:]+)\|(.*?)\]\]')
+
+zotxtroot = 'http://127.0.0.1:23119/zotxt/items?'
+
+def fetchkey(easykey):
+    data = {
+            'easykey':easykey,
+            'format': 'key'
+           }
+    url = zotxtroot + urlencode(data)
+    resp = json.loads(urlopen(url).read().decode('utf-8'))
+    return resp[0]
+
+def matchkey(m):
+    if m.group(1) == '':
+        key = m.group(2)
+    elif m.group(1) == 'easy':
+        key = ''
+        try:
+            key = fetchkey(m.group(2))
+        except Exception as e:
+            print(f'ERROR: got an exception {e}')
+            print(m.group[0])
+    elif m.group(1) == 'betterbibtex':
+        key = '@' + m.group(2)
+    else:
+        key = ''
+        print(f'ERROR: found something unspecified: {m.group(0)}')
+        print(m.group[0])
+    return f'[[zotero://select/items/{key}|{m.group(3)}]]'
+
+def updatefile(filename, backup=True):
+    backupfile = filename + '.bak'
+    os.rename(filename, backupfile)
+    with open(backupfile, 'r') as bf, open(filename, 'w') as f:
+        for line in bf.readlines():
+            line = patternkey.sub(matchkey, line)
+            f.write(line)
+    if not backup:
+        os.remove(backupfile)
+
+def walkdir(dirname, backup=True):
+    for dirpath, dirnames, files in os.walk(dirname):
+        print(f'Found directory: {dirpath}')
+        for filename in files:
+            filename = os.path.join(dirpath, filename)
+            if not filename.endswith('.txt'):
+                print(f'{filename} Skipped')
+                continue
+            updatefile(filename, backup)
+            print(f'{filename} Processed')
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='This program converts the Zotero links '
+            'of the old format into the Zotero own link. Zotero should run.')
+    parser.add_argument('-b', '--nobackup', action='store_false',
+            help='Do not retain the original files as *.bak')
+
+    def dirpath(string):
+        path = os.path.abspath(string)
+        if not os.path.isdir(path):
+            msg = 'is not a directory'
+            raise argparse.ArgumentTypeError(msg)
+        return path
+    parser.add_argument('dir', type=dirpath, help='Root directory of the zim wiki')
+
+    args = parser.parse_args()
+
+    walkdir(args.dir, args.nobackup)

--- a/zotero_link_handler.sh
+++ b/zotero_link_handler.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo $1 | sed 's/zotero/http/g' | xargs curl

--- a/zotxt-select.py
+++ b/zotxt-select.py
@@ -1,0 +1,35 @@
+#!/bin/python3
+
+from urllib.request import urlopen
+from urllib.parse import urlencode
+import re
+
+
+zotxturl = "http://127.0.0.1:23119/zotxt/"
+zotxturlselect = zotxturl + 'select?'
+linkurl = "zotero://select/items/"
+pattern = re.escape(linkurl) + r'([@]*)(.+)'
+pattern = re.compile(pattern)
+
+def main(arg):
+    data = {}
+    m = pattern.match(arg)
+    if m.group(1) == '@':
+        data['betterbibtexkey'] = m.group(2)
+    else:
+        data['key'] = m.group(2)
+    data = urlencode(data)
+    url = zotxturlselect + data
+    try:
+        urlopen(url)
+    except Exception as e:
+        print(f'ERROR: got an exception {e}\n{m.group(0)}\n{url}')
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='This program use zotxt to select an '
+            'entry in Zotero')
+    parser.add_argument('url', help='Zotero URL')
+
+    args = parser.parse_args()
+    main(args.url)


### PR DESCRIPTION
Shivams thanks for the plugin. In the last month I used it a lot, but I also changed it to fit my needs. Feel free to use all or just a bit of it (sadly I have only one commit). 

The rework of the dialog was done, so I use the dialog only with the keyboard (Enter will start the search) 

The change of the link format was done, so I could copy them out of zim and use it wherever I want (the README explains the setup)

- The dialog uses now the zim form template for generation of the inputs.
- The urllib is used to generate the get parameter for zotxt
- The zotero:// links use the pattern of Zotero, so they can be copied to other programs
- No external script is used to select the entry in Zotero
- easykey need to be removed, as there is no direct link for it (could be added if for every easykey the internal or betterbibtex key is fetched)
- There is now an option in preferences for choosing the style format of the `bibliography` reference. So it can be changed without changing it in Zotero

Improvements:
- ~~[ ] Test it with python2~~
- [x] Add a migration path to the new link format: Could be a regex/python script
- [ ] Test the converter script
- [ ] Test it with windows (if someone is using it)

Let me know if you want to include it.